### PR TITLE
Create unnamed tunnel if no identifier is specified

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,10 @@ util.inherits(SauceTunnel, EventEmitter);
 
 SauceTunnel.prototype.openTunnel = function(callback) {
   var me = this;
-  var args = ["-jar", __dirname + "/vendor/Sauce-Connect.jar", this.user, this.key, "-i", this.identifier];
+  var args = ["-jar", __dirname + "/vendor/Sauce-Connect.jar", this.user, this.key];
+  if (this.identifier) {
+    args.push("-i", this.identifier);
+  }
   this.proc = proc.spawn('java', args);
   var calledBack = false;
 


### PR DESCRIPTION
Currently sauce-tunnel doesn't support tunnels without identifiers. This patch adds that; if no identifier is specified, no -i arg is passed to sauce-connect.jar, and the tunnel is created as a default unnamed tunnel instead.
