### PR TITLE
added the ability to pass extra option flags when starting the tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,13 @@ future Node module that may need it.
 Before starting the tunnel, initialize it first
 
 ```
-var tunnel = new SauceTunnel(SAUCE_USERNAME, SAUCE_ACCESSKEY, tunnelIdentifier, tunneled);
+var tunnel = new SauceTunnel(SAUCE_USERNAME, SAUCE_ACCESSKEY, tunnelIdentifier, tunneled, extraFlags);
 ```
 
 1. `SAUCE_USERNAME` and `SAUCE_ACCESSKEY` are the username and the accesskey for saucelabs. They are usually set as environment variables (specially in continuous integration tools like [travis](http://travis-ci.org) ) 
 2. The `tunnelIdentifier` is a unique identifier for the tunnel. It is optional and is automatically generated when not specified. Note that the tunnel identifier may have to be passed in with the browsers object as a desired capability to enable traffic to use the tunnel. More details [here](https://saucelabs.com/docs/additional-config#tunnel-identifier)
 3. The `tunneled` attribute is a boolean value to indicate if the tunnel is to be created or not. This value can be set to `false` to mock a tunnel creation if the site tested is publically accessible. To create a tunnel, set this value to `true`.
+4. The ``extraFlags`` attribute is an optioonal array of options flags (see [here](https://saucelabs.com/docs/connect)). Example: ``['--debug', '--direct-domains', 'www.google.com']``
 
 One the tunnel is initialized, start the tunnel using it with the following command. 
 
@@ -45,7 +46,7 @@ To get started easily, here is the code you can copy paste
 
 ```
 var SauceTunnel = require('sauce-tunnel');
-var tunnel = new SauceTunnel(process.env.SAUCE_USERNAME, process.env.SAUCE_ACCESSKEY, 'tunnel', true);
+var tunnel = new SauceTunnel(process.env.SAUCE_USERNAME, process.env.SAUCE_ACCESSKEY, 'tunnel', true/* ['--debug'] */);
 tunnel.start(function(status){
   if (status === false){
     throw new Error('Something went wrong with the tunnel');

--- a/index.js
+++ b/index.js
@@ -9,13 +9,14 @@ var EventEmitter = require('events').EventEmitter;
 
 module.exports = SauceTunnel;
 
-function SauceTunnel(user, key, identifier, tunneled) {
+function SauceTunnel(user, key, identifier, tunneled, extraFlags) {
   EventEmitter.call(this);
   this.user = user;
   this.key = key;
   this.identifier = identifier || 'Tunnel'+new Date().getTime();
   this.tunneled = tunneled;
   this.baseUrl = ["https://", this.user, ':', this.key, '@saucelabs.com', '/rest/v1/', this.user].join("");
+  this.extraFlags = extraFlags;
 }
 
 util.inherits(SauceTunnel, EventEmitter);
@@ -25,6 +26,9 @@ SauceTunnel.prototype.openTunnel = function(callback) {
   var args = ["-jar", __dirname + "/vendor/Sauce-Connect.jar", this.user, this.key];
   if (this.identifier) {
     args.push("-i", this.identifier);
+  }
+  if (this.extraFlags) {
+    args = args.concat(this.extraFlags);
   }
   this.proc = proc.spawn('java', args);
   var calledBack = false;


### PR DESCRIPTION
Hi,

Happy new year!

I added a way to pass extra option flags to the command that starts the tunnel. I'm using it to specifify a list of direct domains (to speed up the tests). I hope you find it useful.
