### PR TITLE
Replace `colors` with `chalk`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 /* npm */
-var colors = require('colors');
+var chalk = require('chalk');
 var request = require('request').defaults({jar:false});
 
 /* core */
@@ -114,7 +114,7 @@ SauceTunnel.prototype.start = function(callback) {
   if (!this.tunneled) {
     return callback(true);
   }
-  this.emit('verbose:writeln', "=> Sauce Labs trying to open tunnel".inverse);
+  this.emit('verbose:writeln', chalk.inverse("=> Sauce Labs trying to open tunnel"));
   this.openTunnel(function(status) {
     callback(status);
   });

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "colors": "~0.6.0-1",
-    "request": "~2.21.0"
+    "request": "~2.21.0",
+    "chalk": "~0.4.0"
   }
 }


### PR DESCRIPTION
`colors` extends the `String` prototype, which can have side effects
for other modules, so use `chalk` instead.
