### PR TITLE
Fix delete tunnel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /node_modules/
 *.DS_Store
-npm-debug.log
+*.log

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "chalk": "~0.4.0",
     "request": "~2.21.0",
-    "chalk": "~0.4.0"
+    "split": "~0.3.2"
   }
 }

--- a/test/sanity.js
+++ b/test/sanity.js
@@ -1,5 +1,5 @@
 var SauceTunnel = require('../index');
-var tunnel = new SauceTunnel(process.env.SAUCE_USERNAME, process.env.SAUCE_ACCESS_KEY, 'tunnel', true, ['--verbose']);
+var tunnel = new SauceTunnel(process.env.SAUCE_USERNAME, process.env.SAUCE_ACCESSKEY, 'tunnel', true, ['--verbose']);
 tunnel.on('verbose:ok', function () {
   console.log.apply(console, arguments);
 });

--- a/test/sanity.js
+++ b/test/sanity.js
@@ -1,5 +1,5 @@
 var SauceTunnel = require('../index');
-var tunnel = new SauceTunnel(process.env.SAUCE_USERNAME, process.env.SAUCE_ACCESSKEY, 'tunnel', true, ['--verbose']);
+var tunnel = new SauceTunnel(process.env.SAUCE_USERNAME, process.env.SAUCE_ACCESS_KEY, 'tunnel', true, ['--verbose']);
 tunnel.on('verbose:ok', function () {
   console.log.apply(console, arguments);
 });


### PR DESCRIPTION
To delete a tunnel, Sauce Labs' REST API expects an id which is different from the tunnel-identifier specified as the -i parameter of Sauce Connect.
Also fixed the SAUCE_ACCESS_KEY environment variable in the test file.