### PR TITLE
Make `tunneled` an optional parameter that defaults to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ var tunnel = new SauceTunnel(SAUCE_USERNAME, SAUCE_ACCESSKEY, tunnelIdentifier, 
 
 1. `SAUCE_USERNAME` and `SAUCE_ACCESSKEY` are the username and the accesskey for saucelabs. They are usually set as environment variables (specially in continuous integration tools like [travis](http://travis-ci.org) )
 2. The `tunnelIdentifier` is a unique identifier for the tunnel. It is optional and is automatically generated when not specified. Note that the tunnel identifier may have to be passed in with the browsers object as a desired capability to enable traffic to use the tunnel. More details [here](https://saucelabs.com/docs/additional-config#tunnel-identifier)
-3. The `tunneled` attribute is a boolean value to indicate if the tunnel is to be created or not. This value can be set to `false` to mock a tunnel creation if the site tested is publically accessible. To create a tunnel, set this value to `true`.
+3. The `tunneled` attribute is a boolean value to indicate if the tunnel is to be created or not. This value can be set to `false` to mock a tunnel creation if the site tested is publicly accessible. This value is optional and defaults to `true`.
 4. The ``extraFlags`` attribute is an array of options flags (see [here](https://saucelabs.com/docs/connect)). Example: ``['--debug', '--direct-domains', 'www.google.com']``. It is optional.
 
 Once the tunnel is initialized, start it with the following command.

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function SauceTunnel(user, key, identifier, tunneled, extraFlags) {
   this.user = user;
   this.key = key;
   this.identifier = identifier || 'Tunnel'+new Date().getTime();
-  this.tunneled = tunneled;
+  this.tunneled = (tunneled == null) ? true : tunneled;
   this.baseUrl = ["https://", this.user, ':', this.key, '@saucelabs.com', '/rest/v1/', this.user].join("");
   this.extraFlags = extraFlags;
 }

--- a/test/sanity.js
+++ b/test/sanity.js
@@ -1,5 +1,16 @@
 var SauceTunnel = require('../index');
-var tunnel = new SauceTunnel(process.env.SAUCE_USERNAME, process.env.SAUCE_ACCESSKEY, 'tunnel', true, ['--verbose']);
+
+var tunnel = new SauceTunnel(process.env.SAUCE_USERNAME, process.env.SAUCE_ACCESSKEY);
+if (!tunnel.identifier) {
+  console.error('`tunnel.identifier` should be set to a random variable when not specified in the constructor');
+  process.exit(1);
+}
+if (tunnel.tunneled !== true) {
+  console.error('`tunnel.tunneled` should be set to `true` when not specified in the constructor');
+  process.exit(1);
+}
+
+tunnel = new SauceTunnel(process.env.SAUCE_USERNAME, process.env.SAUCE_ACCESSKEY, 'tunnel', true, ['--verbose']);
 tunnel.on('verbose:ok', function () {
   console.log.apply(console, arguments);
 });
@@ -17,7 +28,7 @@ tunnel.start(function(status){
   tunnel.stop(function(err){
     if(err){
       console.error(err);
-      process.exit(1); 
+      process.exit(1);
     }
     console.log('Tunnel destroyed');
     process.exit(0);


### PR DESCRIPTION
Without the `tunneled` parameter set to `true`, the created `SauceTunnel` is essentially useless.
This PR makes the `tunneled` parameter optional so that it defaults to `true` when not specified in the `SauceTunnel` constructor (or when it is specified as `null` or `undefined`).

Fixes #8