### PR TITLE
Fix for the race condition in SauceTunnel.stop()

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,10 +127,22 @@ SauceTunnel.prototype.start = function(callback) {
   });
 };
 
-SauceTunnel.prototype.stop = function(callback) {
-  this.killTunnel(function(err) {
-    this.kill(callback.bind(this, err));
-  }.bind(this));
+SauceTunnel.prototype.stop = function (callback) {
+  var self = this,
+    callbackArg;
+
+  this.proc.on('exit', function () {
+    callback(callbackArg);
+  });
+
+  this.killTunnel(function (err) {
+    // When deleting the tunnel via the REST API succeeds, then Sauce Connect exits automatically.
+    // Otherwise kill the process. Don't care with the tunnel, it will time out.
+    if (err) {
+      callbackArg = err;
+      self.proc.kill();
+    }
+  });
 };
 
 SauceTunnel.prototype.kill = function(callback) {


### PR DESCRIPTION
stop() tries to close the tunnel then kills the Sauce Connect process regardless of the result of the first operation.
There is a race condition here, because Sauce Connect automatically exits after the tunnel is successfully closed. If Sauce Connect exits before the event listener is set up in kill() then the user-provided callback will never be invoked.
The fix:
* only kills the process when closing the tunnel fails
* sets up a common event handler which handles the exit event regardless of what caused the process to exit.