### PR TITLE
Fix flakey test due to Travis-CI parallelism

### DIFF
--- a/test/sanity.js
+++ b/test/sanity.js
@@ -10,7 +10,7 @@ if (tunnel.tunneled !== true) {
   process.exit(1);
 }
 
-tunnel = new SauceTunnel(process.env.SAUCE_USERNAME, process.env.SAUCE_ACCESSKEY, 'tunnel', true, ['--verbose']);
+tunnel = new SauceTunnel(process.env.SAUCE_USERNAME, process.env.SAUCE_ACCESSKEY, null, true, ['--verbose']);
 tunnel.on('verbose:ok', function () {
   console.log.apply(console, arguments);
 });


### PR DESCRIPTION
It looks like the [last Travis-CI test run](https://travis-ci.org/jmreidy/sauce-tunnel/jobs/54755969) on master failed because Travis tried to run the tests on both versions of Node at the same time. The second test tried to open a tunnel with the same identifier as the first test, but since that identifier was already being used by the first test, the second tunnel was rejected, so the test failed ([error log line](https://travis-ci.org/jmreidy/sauce-tunnel/jobs/54755969#L145)).

This PR makes the tests use the default tunnel identifier value, which is a random(ish) identifier string based on the current UTC time in milliseconds, so collisions like this will be very unlikely to happen.